### PR TITLE
Rename conf file and provide example that adds mining node

### DIFF
--- a/share/examples/argentumntcoin.conf
+++ b/share/examples/argentumntcoin.conf
@@ -1,0 +1,4 @@
+# Copy this file to ~/.argentumntcoin/
+# Recommended node
+addnode=194.182.164.249
+

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -73,7 +73,7 @@
 // Application startup time (used for uptime calculation)
 const int64_t nStartupTime = GetTime();
 
-const char * const BITCOIN_CONF_FILENAME = "bitcoin.conf";
+const char * const BITCOIN_CONF_FILENAME = "argentumntcoin.conf";
 
 ArgsManager gArgs;
 


### PR DESCRIPTION
Previously, a the configuration file was located at `~/.argentumntcoin/bitcoin.conf`, now at  `~/.argentumntcoin/argentumntcoin.conf`.

The `addnode` in the example conf is needed to get synchronization starting.